### PR TITLE
Adjust autoloading

### DIFF
--- a/Controller/InfiniteScrollController.php
+++ b/Controller/InfiniteScrollController.php
@@ -5,7 +5,7 @@
  * Date: 29/07/15
  * Time: 11:15
  */
-namespace InfiniteScroll\Controller;
+namespace Bolt\Extension\Locastic\InfiniteScroll\Controller;
 
 use Silex\Application;
 use Silex\ControllerCollection;
@@ -41,7 +41,7 @@ class InfiniteScrollController implements ControllerProviderInterface
             return 'Not a valid contenttype';
         }
 
-        if($request->getMethod() == 'GET') {
+        if ($this->app['request']->isMethod('GET')) {
             $page = $request->request->get('page');
 
             $amount = (!empty($contenttype['listing_records']) ? $contenttype['listing_records'] : $this->app['config']->get('general/listing_records'));

--- a/Extension.php
+++ b/Extension.php
@@ -2,15 +2,13 @@
 
 namespace Bolt\Extension\Locastic\InfiniteScroll;
 
-use Bolt;
-use InfiniteScroll\Controller\InfiniteScrollController;
-use Symfony\Component\HttpFoundation\Request;
+use Bolt\BaseExtension;
 
-class Extension extends Bolt\BaseExtension
+class Extension extends BaseExtension
 {
     public function initialize()
     {
-        $this->app->mount('/infinitescroll/{contenttypeslug}', new InfiniteScrollController());
+        $this->app->mount('/infinitescroll/{contenttypeslug}', new Controller\InfiniteScrollController());
 
         $this->addJavascript('assets/start.js', true);
         $this->addJavascript('assets/jscroll/jquery.jscroll.js', true);

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "bolt-extension",
     "keywords": ["bolt", "ajax", "listing", "infinite scroll"],
     "require": {
-        "bolt/bolt": ">=2.0.0,<3.0.0"
+        "bolt/bolt": ">=2.0.0,<3.0.0",
+        "php": ">=5.4.0"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,9 @@
             "init.php"
         ],
         "psr-4": {
-            "Bolt\\Extension\\Locastic\\InfiniteScroll\\": ["", "assets/"]
+            "Bolt\\Extension\\Locastic\\InfiniteScroll\\": [""]
         }
     },
-    
     "extra": {
         "bolt-assets": "assets"
     }


### PR DESCRIPTION
- The `assets/` directory isn't needed for the PSR-4 autoloader
- Added a PHP requirement of >= 5.4 as this extension uses short array syntax :+1: 
- Adjusted the namespace on the controller so it's found by the autoloader

Welcome to our community! Great to have you here :grin: 
