### PR TITLE
Deprecated function use & unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_*
+composer.lock
+vendor/
+tests/tmp/
+

--- a/Controller/InfiniteScrollController.php
+++ b/Controller/InfiniteScrollController.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class InfiniteScrollController implements ControllerProviderInterface
 {
-    public $app;
+    private $app;
 
     /**
      * Returns routes to connect to the given application.
@@ -30,7 +30,6 @@ class InfiniteScrollController implements ControllerProviderInterface
         $ctr->match('', [$this, 'infiniteScroll'])
             ->method('GET');
 
-
         return $ctr;
     }
 
@@ -41,7 +40,7 @@ class InfiniteScrollController implements ControllerProviderInterface
             return 'Not a valid contenttype';
         }
 
-        if ($this->app['request']->isMethod('GET')) {
+        if ($request->isMethod('GET')) {
             $page = $request->request->get('page');
 
             $amount = (!empty($contenttype['listing_records']) ? $contenttype['listing_records'] : $this->app['config']->get('general/listing_records'));

--- a/Extension.php
+++ b/Extension.php
@@ -10,9 +10,9 @@ class Extension extends BaseExtension
     {
         $this->app->mount('/infinitescroll/{contenttypeslug}', new Controller\InfiniteScrollController());
 
-        $this->addJavascript('assets/start.js', true);
-        $this->addJavascript('assets/jscroll/jquery.jscroll.js', true);
-        $this->addJavascript('assets/jscroll/jquery.jscroll.min.js', true);
+        $this->addJavascript('assets/start.js', ['late' => true]);
+        $this->addJavascript('assets/jscroll/jquery.jscroll.js', ['late' => true]);
+        $this->addJavascript('assets/jscroll/jquery.jscroll.min.js', ['late' => true]);
 
         $this->addTwigFunction('infiniteScroll', 'twigInfiniteScroll');
 
@@ -32,9 +32,3 @@ class Extension extends BaseExtension
         return "InfiniteScroll";
     }
 }
-
-
-
-
-
-

--- a/Extension.php
+++ b/Extension.php
@@ -13,13 +13,11 @@ class Extension extends BaseExtension
         $this->app->before([$this, 'before']);
 
         $this->addTwigFunction('infiniteScroll', 'twigInfiniteScroll');
-
     }
 
     public function before()
     {
         $this->addJavascript('assets/start.js', ['late' => true]);
-        $this->addJavascript('assets/jscroll/jquery.jscroll.js', ['late' => true]);
         $this->addJavascript('assets/jscroll/jquery.jscroll.min.js', ['late' => true]);
     }
 

--- a/Extension.php
+++ b/Extension.php
@@ -10,15 +10,20 @@ class Extension extends BaseExtension
     {
         $this->app->mount('/infinitescroll/{contenttypeslug}', new Controller\InfiniteScrollController());
 
-        $this->addJavascript('assets/start.js', ['late' => true]);
-        $this->addJavascript('assets/jscroll/jquery.jscroll.js', ['late' => true]);
-        $this->addJavascript('assets/jscroll/jquery.jscroll.min.js', ['late' => true]);
+        $this->app->before([$this, 'before']);
 
         $this->addTwigFunction('infiniteScroll', 'twigInfiniteScroll');
 
     }
 
-    function twigInfiniteScroll()
+    public function before()
+    {
+        $this->addJavascript('assets/start.js', ['late' => true]);
+        $this->addJavascript('assets/jscroll/jquery.jscroll.js', ['late' => true]);
+        $this->addJavascript('assets/jscroll/jquery.jscroll.min.js', ['late' => true]);
+    }
+
+    public function twigInfiniteScroll()
     {
         $html = '<div id="infinite-scroll"></div>
                 <div id="infinite-scroll-bottom"></div>';

--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,43 @@
 {
-    "name": "locastic/infinitescroll",
-    "description": "Listing of contenttype entries with infinite scroll",
-    "type": "bolt-extension",
-    "keywords": ["bolt", "ajax", "listing", "infinite scroll"],
-    "require": {
-        "bolt/bolt": ">=2.0.0,<3.0.0",
-        "php": ">=5.4.0"
+    "name" : "locastic/infinite_scroll",
+    "description" : "Listing of contenttype entries with infinite scroll",
+    "type" : "bolt-extension",
+    "keywords" : [
+        "bolt",
+        "ajax",
+        "listing",
+        "infinite scroll"
+    ],
+    "require" : {
+        "bolt/bolt" : ">=2.2.6,<3.0.0",
+        "php" : ">=5.4.0"
     },
-    "license": "MIT",
+    "require-dev" : {
+        "phpunit/phpunit" : "^4.0"
+    },
     "minimum-stability" : "dev",
     "prefer-stable" : true,
-    "authors": [
-        {
-            "name": "Paula Čučuk",
-            "email": "paula.cucuk@gmail.com"
+    "license" : "MIT",
+    "authors" : [{
+            "name" : "Paula Čučuk",
+            "email" : "paula.cucuk@gmail.com"
         }
     ],
-    "autoload": {
-        "files": [
+    "autoload" : {
+        "files" : [
             "init.php"
         ],
-        "psr-4": {
-            "Bolt\\Extension\\Locastic\\InfiniteScroll\\": ""
+        "psr-4" : {
+            "Bolt\\Extension\\Locastic\\InfiniteScroll\\" : ""
         }
+    },
+    "autoload-dev" : {
+        "psr-4" : {
+            "Bolt\\Extension\\Locastic\\InfiniteScroll\\Tests\\" : "tests/",
+            "Bolt\\Tests\\" : "vendor/bolt/bolt/tests/phpunit/unit/"
+        }
+    },
+    "extra" : {
+        "bolt-assets" : "assets"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <listeners>
+        <listener file="vendor/bolt/bolt/tests/phpunit/BoltListener.php" class="Bolt\Tests\BoltListener">
+           <arguments>
+              <!-- Configuration files. Can be either .yml or .yml.dist files -->
+              <!-- Locations can be relative to TEST_ROOT directory, the Bolt directory, or an absolute path -->
+              <array>
+                  <element key="config">
+                      <string>vendor/bolt/bolt/app/config/config.yml.dist</string>
+                  </element>
+                  <element key="contenttypes">
+                      <string>vendor/bolt/bolt/app/config/contenttypes.yml.dist</string>
+                  </element>
+                  <element key="menu">
+                      <string>vendor/bolt/bolt/app/config/menu.yml.dist</string>
+                  </element>
+                  <element key="permissions">
+                      <string>vendor/bolt/bolt/app/config/permissions.yml.dist</string>
+                  </element>
+                  <element key="routing">
+                      <string>vendor/bolt/bolt/app/config/routing.yml.dist</string>
+                  </element>
+                  <element key="taxonomy">
+                      <string>vendor/bolt/bolt/app/config/taxonomy.yml.dist</string>
+                  </element>
+              </array>
+              <!-- Theme directory. Can be relative to TEST_ROOT directory, the Bolt directory, or an absolute path -->
+              <array>
+                  <element key="theme">
+                      <string>theme/base-2014</string>
+                  </element>
+              </array>
+              <!-- The Bolt SQLite database, leave empty to use the one bundled with Bolt's repository -->
+              <!-- Location can be relative to TEST_ROOT directory, the Bolt directory, or an absolute path -->
+              <array>
+                  <element key="boltdb">
+                      <string>vendor/bolt/bolt/tests/phpunit/unit/resources/db/bolt.db</string>
+                  </element>
+              </array>
+              <!-- Reset the cache and test temporary directories -->
+              <boolean>true</boolean>
+              <!-- Create timer output in app/cache/phpunit-test-timer.txt -->
+              <boolean>true</boolean>
+           </arguments>
+        </listener>
+    </listeners>
+    <filter>
+        <blacklist>
+            <directory>vendor</directory>
+            <file>init.php</file>
+        </blacklist>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <file>Extension.php</file>
+            <directory suffix=".php">Controller</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Bolt\Extensions\Locastic\InfiniteScroll\Tests;
+
+use Bolt\BaseExtension;
+use Bolt\Extension\Locastic\InfiniteScroll\Extension;
+use Bolt\Tests\BoltUnitTest;
+use Symfony\Component\HttpFoundation\Request;
+
+class ExtensionTest extends BoltUnitTest
+{
+    public function testExtensionInitialize()
+    {
+        $app = $this->getApp();
+        $extension = new Extension($app);
+        $app['extensions']->register($extension);
+        $name = $extension->getName();
+        $this->assertSame($name, 'InfiniteScroll');
+        $this->assertSame($extension, $app["extensions.$name"]);
+    }
+
+    public function testAssetInsertion()
+    {
+        $this->resetDb();
+        $app = $this->getApp();
+        $this->addDefaultUser($app);
+        $app['request'] = Request::create('/');
+
+        $extension = new Extension($app);
+        $app['extensions']->register($extension);
+
+        $response = $app->handle($app['request']);
+        $html = (string) $response;
+
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertRegExp('#<script src="\S+assets/start.js\S+></script>#', $html);
+        $this->assertRegExp('#<script src="\S+assets/jscroll/jquery.jscroll.min.js\S+></script>#', $html);
+    }
+
+    public function testTwigCallback()
+    {
+        $app = $this->getApp();
+        $extension = new Extension($app);
+
+        $twig = $extension->twigInfiniteScroll();
+        $html = (string) $twig;
+
+        $this->assertInstanceOf('\Twig_Markup', $twig);
+        $this->assertRegExp('#<div id="infinite-scroll"></div>#', $html);
+        $this->assertRegExp('#<div id="infinite-scroll-bottom"></div>#', $html);
+    }
+}

--- a/tests/InfiniteScrollControllerTest.php
+++ b/tests/InfiniteScrollControllerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Bolt\Extensions\Locastic\InfiniteScroll\Tests;
+
+use Bolt\BaseExtension;
+use Bolt\Extension\Locastic\InfiniteScroll\Controller\InfiniteScrollController;
+use Bolt\Extension\Locastic\InfiniteScroll\Extension;
+use Bolt\Tests\BoltUnitTest;
+use Symfony\Component\HttpFoundation\Request;
+
+class InfiniteScrollControllerTest extends BoltUnitTest
+{
+    public function setUp()
+    {
+        $this->resetDb();
+        $app = $this->getApp();
+        $this->addDefaultUser($app);
+    }
+
+    public function testInvalidContentType()
+    {
+        $app = $this->getApp();
+        $extension = new Extension($app);
+        $app['extensions']->register($extension);
+
+        $controller = new InfiniteScrollController();
+        $controller->connect($app);
+
+        $request = Request::create('/infinitescroll/koalas');
+        $app['request'] = $request;
+
+        $response = $controller->infiniteScroll('koalas', $request);
+
+        $this->assertSame('Not a valid contenttype', $response);
+    }
+
+    public function testGet()
+    {
+        $app = $this->getApp();
+        $app['storage']->prefill(['pages']);
+        $app['storage']->prefill(['pages']);
+        $app['storage']->prefill(['pages']);
+        $extension = new Extension($app);
+        $app['extensions']->register($extension);
+
+        $controller = new InfiniteScrollController();
+        $controller->connect($app);
+
+        $request = Request::create('/infinitescroll/pages');
+        $app['request'] = $request;
+
+        $response = $controller->infiniteScroll('pages', $request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $response);
+    }
+
+    public function testGetEmpty()
+    {
+        $app = $this->getApp();
+        $app['storage']->prefill(['pages']);
+        $app['storage']->prefill(['pages']);
+        $app['storage']->prefill(['pages']);
+        $extension = new Extension($app);
+        $app['extensions']->register($extension);
+
+        $storage = $this->getMock('\Bolt\Storage', ['getContent'], [$app]);
+        $storage->expects($this->once())
+            ->method('getContent')
+            ->willReturn(false);
+        $app['storage'] = $storage;
+
+        $controller = new InfiniteScrollController();
+        $controller->connect($app);
+
+        $request = Request::create('/infinitescroll/pages');
+        $app['request'] = $request;
+
+        $response = $controller->infiniteScroll('pages', $request);
+
+        $this->assertSame('No more posts', $response);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+include_once __DIR__ . '/../vendor/bolt/bolt/tests/phpunit/bootstrap.php';
+
+define('EXTENSION_AUTOLOAD',  realpath(dirname(__DIR__) . '/vendor/autoload.php'));
+
+require_once EXTENSION_AUTOLOAD;
+


### PR DESCRIPTION
Hi @paullla 

OK, so I was debugging an error in core with extensions, and using your extension as a test bed

Anyway, I noticed in my logs that `addJavascript()` was being used the old way, and that ends up in the logs. So I thought it's be cool to PR that… then I thought "well, what about unit tests?"… and then 5 minute PR ended up a little bigger than I thought :grin: 

**Details:**
- Moved `addJavascript()` calls to up-to-date format
- Moved `addJavascript()` calls into a middleware handler so that they're only added during a request cycle
- Removed the insertion of `jscroll.js` as the extension is already adding the minified version `jscroll.min.js`
- Added unit test, which brings test coverage to `Lines:   97.30% (36/37)` (it's actually 100% but PHPUnit can't count)
- Bumped minimum Bolt version to 2.2.6 (mainly for unit test coverage, but that can be reverted)

I am happy to remove any parts that you don't like :+1: 

Apologies for the number of lines changed in `composer.json`, my IDE reformats everything automatically.

Thanks for a great extension!
